### PR TITLE
Fix undeclared variable error

### DIFF
--- a/vtil/vtil.py
+++ b/vtil/vtil.py
@@ -218,6 +218,7 @@ class VTIL(Architecture):
 
         if code != None and code.startswith("js"):
             try:
+                _, _, true, false = code.split(" ")
                 true = find_block_address(int(true, 16), active_vtil_file)
                 false = find_block_address(int(false, 16), active_vtil_file)
                 result.add_branch(BranchType.TrueBranch, true)


### PR DESCRIPTION
It appears that here https://github.com/vtil-project/VTIL-BinaryNinja/commit/92940548328cde7f5deaf8d51e274101c5e151ec#diff-8f271e06ab871d806ec5649559a19e1aL220 some code was refactored but the `.split` condition was not moved under the `try`